### PR TITLE
Allow customization of source/include directory names.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -9,6 +9,8 @@
 
 source_path ?= .
 build_path  ?= ./build
+include_subdir ?= include
+source_subdir ?= source
 arch        ?= amd64
 mode        ?= debug
 shell_name  ?= $(if $(WINDIR),cmd,sh)

--- a/headers.mk
+++ b/headers.mk
@@ -24,7 +24,7 @@ endif
 
 
 # Figure out the include path for this component definition
-def_header_path        := $(def_path)/include
+def_header_path        := $(def_path)/$(include_subdir)
 def_header_output_path := $(header_output_path)/$(name)
 
 define header_file_rule

--- a/toolchain/gcc/compile.mk
+++ b/toolchain/gcc/compile.mk
@@ -24,7 +24,7 @@ full_compile_goal_path :=
 
 
 c_toolchain_path    := $(weld_path)/toolchain/gcc
-def_source_path     := $(def_path)/source
+def_source_path     := $(def_path)/$(source_subdir)
 def_obj_output_path := $(obj_output_path)/$(name)
 
 


### PR DESCRIPTION
This allows users of weld to use a different directory structure than the default `include/` and `source/` directories for headers and source files respectively.

Many projects use `src/` for implementation files, and don't place headers in a separate directory.

This does not impact install directories.
