### PR TITLE
Raw lib list

### DIFF
--- a/toolchain/clang/compile.mk
+++ b/toolchain/clang/compile.mk
@@ -10,7 +10,6 @@
 c_toolchain_path       :=
 def_source_path        :=
 def_obj_output_path    :=
-compiler_flag_list     :=
 source_file            :=
 def_source_file        :=
 obj_alias              :=

--- a/toolchain/clang/compile.mk
+++ b/toolchain/clang/compile.mk
@@ -157,7 +157,7 @@ $(compile_goal) :
                 $(link_flag_list)                                                             \
                 $(addprefix -L,$(call path_to_native,$(lib_path_list)))                       \
                 $(call path_to_native,$(obj_goal_file_list))                                  \
-                $(addprefix -l,$(lib_list) $(source_lib_list)) )
+                $(addprefix -l,$(lib_list) $(source_lib_list)) $(raw_lib_list) )
     endif
 
 .PHONY : clean_$(name)_def_compile

--- a/toolchain/gcc/compile.mk
+++ b/toolchain/gcc/compile.mk
@@ -12,7 +12,6 @@
 c_toolchain_path       :=
 def_source_path        :=
 def_obj_output_path    :=
-compiler_flag_list     :=
 source_file            :=
 def_source_file        :=
 obj_alias              :=

--- a/toolchain/gcc/compile.mk
+++ b/toolchain/gcc/compile.mk
@@ -161,7 +161,7 @@ $(compile_goal) :
                 $(link_flag_list)                                                                 \
                 $(addprefix -L,$(call path_to_native,$(lib_path_list)))                           \
                 $(call path_to_native,$(obj_goal_file_list))                                      \
-                -Wl,--start-group $(addprefix -l,$(lib_list) $(source_lib_list)) -Wl,--end-group)
+                -Wl,--start-group $(addprefix -l,$(lib_list) $(source_lib_list)) $(raw_lib_list) -Wl,--end-group)
     endif
 
 .PHONY : clean_$(name)_def_compile


### PR DESCRIPTION
Added support for $(raw_lib_list) where user can specify a list of libraries directly into the linker command. This list is assumed to already be in the format understood by the linker tool
(for example: -lSomeLib). Unlike the $(lib_list), no further massaging of the list will take place (so the -l prefix will not be added).

This is useful for including output of pkg-config tools.
For example:

```
raw_lib_list := $(shell llvm-config --system-libs --libs mcjit bitwriter nativecodegen interpreter)
```
